### PR TITLE
docs(WM-109-A): VContainer 메커니즘 source-verified 정립 문서

### DIFF
--- a/Unity/KarmoLab/Assets/_WitchMendokusai/Domain/Seed/SeedLoader.cs
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/Domain/Seed/SeedLoader.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using UnityEngine;
+using WitchMendokusai.DomainSDK.Data;
+using WitchMendokusai.DomainSDK.Serialization;
+
+namespace WitchMendokusai.Domain.Seed
+{
+    /// <summary>
+    /// UGC 시드 로더 (게임 안 로드 + 사용).
+    ///
+    /// OS user data 에서 시드 JSON 로드.
+    /// 시드로 게임 데이터 생성.
+    /// </summary>
+    public class SeedLoader : MonoBehaviour
+    {
+        private UGCJsonSerializer _serializer;
+
+        private void Awake()
+        {
+            _serializer = new UGCJsonSerializer();
+        }
+
+        /// <summary>
+        /// Load a seed from UGC storage by ID.
+        ///
+        /// Loads from %APPDATA%/WitchMendokusai/ugc/{ugcId}.json
+        /// </summary>
+        /// <param name="ugcId">The UGC ID to load.</param>
+        /// <returns>Loaded SeedDataSO, or null if not found or invalid.</returns>
+        public SeedDataSO LoadFromUGC(string ugcId)
+        {
+            if (string.IsNullOrWhiteSpace(ugcId))
+            {
+                Debug.LogError("ugcId cannot be empty");
+                return null;
+            }
+
+            var ugcPath = GetUGCPath(ugcId);
+            if (!File.Exists(ugcPath))
+            {
+                Debug.LogError($"Seed file not found: {ugcPath}");
+                return null;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(ugcPath);
+                var seed = _serializer.Deserialize<SeedDataSO>(json);
+                Debug.Log($"Loaded seed: {seed.ugcId} ({seed.parameters.name})");
+                return seed;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to load seed {ugcId}: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Apply a seed to game data.
+        ///
+        /// This method should be overridden or extended to implement
+        /// actual procedural generation logic.
+        /// </summary>
+        /// <param name="seed">The seed to apply.</param>
+        public void ApplySeedToGame(SeedDataSO seed)
+        {
+            if (seed == null)
+            {
+                Debug.LogError("Seed cannot be null");
+                return;
+            }
+
+            if (!seed.ValidateFields(out string errorMsg))
+            {
+                Debug.LogError($"Seed validation failed: {errorMsg}");
+                return;
+            }
+
+            // TODO: Implement actual procedural generation logic
+            // For now, just log the seed info
+            Debug.Log($"Applying seed: {seed.parameters.name}");
+            Debug.Log($"  RNG seed: {seed.parameters.seed}");
+            Debug.Log($"  Scale: {seed.parameters.scale}");
+            Debug.Log($"  Description: {seed.description}");
+        }
+
+        /// <summary>
+        /// Save a seed to UGC storage.
+        ///
+        /// Saves to %APPDATA%/WitchMendokusai/ugc/{ugcId}.json
+        /// </summary>
+        /// <param name="seed">The seed to save.</param>
+        /// <returns>True if save was successful, false otherwise.</returns>
+        public bool SaveToUGC(SeedDataSO seed)
+        {
+            if (seed == null)
+            {
+                Debug.LogError("Seed cannot be null");
+                return false;
+            }
+
+            if (!seed.ValidateFields(out string errorMsg))
+            {
+                Debug.LogError($"Seed validation failed: {errorMsg}");
+                return false;
+            }
+
+            try
+            {
+                var ugcPath = GetUGCPath(seed.ugcId);
+                var json = _serializer.Serialize(seed);
+                File.WriteAllText(ugcPath, json);
+                Debug.Log($"Saved seed: {ugcPath}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to save seed: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get the full path to a UGC file.
+        /// </summary>
+        private string GetUGCPath(string ugcId)
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var ugcDir = Path.Combine(appData, "WitchMendokusai", "ugc");
+
+            // Ensure directory exists
+            Directory.CreateDirectory(ugcDir);
+
+            return Path.Combine(ugcDir, $"{ugcId}.json");
+        }
+    }
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/Domain/WitchMendokusai.Domain.asmdef
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/Domain/WitchMendokusai.Domain.asmdef
@@ -1,0 +1,16 @@
+{
+  "name": "WitchMendokusai.Domain",
+  "rootNamespace": "WitchMendokusai.Domain",
+  "references": [
+    "WitchMendokusai.DomainSDK"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Data/SeedDataSO.cs
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Data/SeedDataSO.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using System;
+
+namespace WitchMendokusai.DomainSDK.Data
+{
+    /// <summary>
+    /// 시드 데이터 (UGC first-use).
+    ///
+    /// Procedural generation seed 저장 (가장 단순).
+    /// DomainSDK 확장 (추가 필드 최소).
+    /// </summary>
+    public class SeedDataSO : UGCDataSO
+    {
+        [System.Serializable]
+        public class SeedParameters
+        {
+            /// <summary>
+            /// RNG seed for procedural generation.
+            /// </summary>
+            public int seed;
+
+            /// <summary>
+            /// Name of the seed.
+            /// </summary>
+            public string name;
+
+            /// <summary>
+            /// Scale factor for terrain/world generation (example).
+            /// </summary>
+            public float scale = 1.0f;
+        }
+
+        /// <summary>
+        /// Parameters for procedural generation.
+        /// </summary>
+        public SeedParameters parameters;
+
+        /// <summary>
+        /// Human-readable description of the seed.
+        /// </summary>
+        public string description;
+
+        public override bool ValidateFields(out string errorMessage)
+        {
+            // Validate base fields first
+            if (!base.ValidateFields(out errorMessage))
+                return false;
+
+            // Validate SeedDataSO-specific fields
+            if (parameters == null)
+            {
+                errorMessage = "parameters cannot be null";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(parameters.name))
+            {
+                errorMessage = "parameters.name cannot be empty";
+                return false;
+            }
+
+            if (parameters.seed < 0)
+            {
+                errorMessage = "parameters.seed cannot be negative";
+                return false;
+            }
+
+            if (parameters.scale <= 0)
+            {
+                errorMessage = "parameters.scale must be positive";
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Data/UGCDataSO.cs
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Data/UGCDataSO.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using System;
+
+namespace WitchMendokusai.DomainSDK.Data
+{
+    /// <summary>
+    /// UGC 데이터 기본 구조 (모든 UGC 가 상속).
+    ///
+    /// JSON 외부화 가능한 필드만 포함.
+    /// DataSO 구조 (Unity 직렬화 호환).
+    ///
+    /// Subclass (SeedDataSO 등) 가 구체 필드 추가 시,
+    /// DomainSDK schema 정의 필드만 허용.
+    /// </summary>
+    public abstract class UGCDataSO : ScriptableObject
+    {
+        /// <summary>
+        /// Unique identifier for this UGC object.
+        /// </summary>
+        public string ugcId;
+
+        /// <summary>
+        /// User who created this UGC object.
+        /// </summary>
+        public string createdBy;
+
+        /// <summary>
+        /// Timestamp when this UGC object was created (ISO 8601 format).
+        /// </summary>
+        public DateTime createdAt;
+
+        /// <summary>
+        /// Virtual method for subclasses to validate their fields.
+        /// Override in subclasses to add custom validation.
+        /// </summary>
+        public virtual bool ValidateFields(out string errorMessage)
+        {
+            errorMessage = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(ugcId))
+            {
+                errorMessage = "ugcId cannot be empty";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(createdBy))
+            {
+                errorMessage = "createdBy cannot be empty";
+                return false;
+            }
+
+            if (createdAt == default)
+            {
+                errorMessage = "createdAt must be set";
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Serialization/UGCJsonSerializer.cs
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/Serialization/UGCJsonSerializer.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using UnityEngine;
+using WitchMendokusai.DomainSDK.Data;
+
+namespace WitchMendokusai.DomainSDK.Serialization
+{
+    /// <summary>
+    /// Validation result for schema validation.
+    /// </summary>
+    public class ValidationResult
+    {
+        public bool IsValid { get; set; }
+        public string ErrorMessage { get; set; }
+        public List<string> InvalidFields { get; set; } = new();
+
+        public ValidationResult() { }
+
+        public ValidationResult(bool isValid, string errorMessage = "")
+        {
+            IsValid = isValid;
+            ErrorMessage = errorMessage;
+        }
+    }
+
+    /// <summary>
+    /// DomainSDK schema 기반 UGC JSON 직렬화.
+    ///
+    /// - 입력: DomainSDK 정의 DataSO (예: SeedDataSO, StoryDataSO 등)
+    /// - 출력: JSON (에디터 친화 + 외부 도구 호환)
+    /// - 검증: JSON → DataSO schema 원형 재구성만 가능 (추가 필드 X)
+    /// </summary>
+    public class UGCJsonSerializer
+    {
+        private readonly JsonSerializerOptions _jsonOptions;
+
+        public UGCJsonSerializer()
+        {
+            _jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters =
+                {
+                    new JsonStringEnumConverter(),
+                    new DateTimeConverter(),
+                }
+            };
+        }
+
+        /// <summary>
+        /// Serialize a DataSO object to JSON string.
+        ///
+        /// Only fields defined in the DomainSDK schema are serialized.
+        /// </summary>
+        /// <param name="dataObject">The ScriptableObject to serialize.</param>
+        /// <returns>JSON string representation of the object.</returns>
+        public string Serialize(ScriptableObject dataObject)
+        {
+            if (dataObject == null)
+                throw new ArgumentNullException(nameof(dataObject));
+
+            if (!(dataObject is UGCDataSO ugcData))
+                throw new ArgumentException($"Object must inherit from UGCDataSO, got {dataObject.GetType().Name}");
+
+            // Create a dictionary from the object's serializable fields
+            var dict = ExtractSerializableFields(ugcData);
+
+            // Serialize to JSON
+            return JsonSerializer.Serialize(dict, _jsonOptions);
+        }
+
+        /// <summary>
+        /// Deserialize a JSON string to a DataSO object of type T.
+        ///
+        /// Validates schema before deserialization.
+        /// </summary>
+        /// <typeparam name="T">The target type (must inherit from UGCDataSO).</typeparam>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <returns>Deserialized object of type T.</returns>
+        public T Deserialize<T>(string json) where T : UGCDataSO
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                throw new ArgumentException("JSON string cannot be empty", nameof(json));
+
+            // Validate schema first
+            var validation = ValidateSchema(json, typeof(T));
+            if (!validation.IsValid)
+                throw new InvalidOperationException($"JSON schema validation failed: {validation.ErrorMessage}");
+
+            // Parse JSON
+            using (var doc = JsonDocument.Parse(json))
+            {
+                var root = doc.RootElement;
+                var instance = ScriptableObject.CreateInstance<T>();
+
+                // Populate base UGCDataSO fields
+                if (root.TryGetProperty("ugcId", out var ugcIdElem))
+                    instance.ugcId = ugcIdElem.GetString();
+
+                if (root.TryGetProperty("createdBy", out var createdByElem))
+                    instance.createdBy = createdByElem.GetString();
+
+                if (root.TryGetProperty("createdAt", out var createdAtElem))
+                {
+                    if (DateTime.TryParse(createdAtElem.GetString(), out var createdAt))
+                        instance.createdAt = createdAt;
+                }
+
+                // Populate derived fields using reflection
+                PopulateFieldsFromJson(instance, root);
+
+                // Validate the deserialized object
+                if (!instance.ValidateFields(out string errorMsg))
+                    throw new InvalidOperationException($"Object validation failed: {errorMsg}");
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// Validate that a JSON string only contains fields defined in the schema type.
+        ///
+        /// Rejects JSON with additional fields not in DomainSDK schema.
+        /// </summary>
+        /// <param name="json">The JSON string to validate.</param>
+        /// <param name="schemaType">The schema type (must inherit from UGCDataSO).</param>
+        /// <returns>ValidationResult with details if validation fails.</returns>
+        public ValidationResult ValidateSchema(string json, Type schemaType)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return new ValidationResult(false, "JSON string cannot be empty");
+
+            if (!typeof(UGCDataSO).IsAssignableFrom(schemaType))
+                return new ValidationResult(false, $"Schema type {schemaType.Name} must inherit from UGCDataSO");
+
+            try
+            {
+                using (var doc = JsonDocument.Parse(json))
+                {
+                    var root = doc.RootElement;
+                    var allowedFields = GetAllowedFields(schemaType);
+
+                    var invalidFields = new List<string>();
+                    foreach (var prop in root.EnumerateObject())
+                    {
+                        if (!allowedFields.Contains(prop.Name))
+                            invalidFields.Add(prop.Name);
+                    }
+
+                    if (invalidFields.Count > 0)
+                    {
+                        var result = new ValidationResult(false,
+                            $"JSON contains fields not in schema: {string.Join(", ", invalidFields)}");
+                        result.InvalidFields = invalidFields;
+                        return result;
+                    }
+
+                    return new ValidationResult(true);
+                }
+            }
+            catch (JsonException ex)
+            {
+                return new ValidationResult(false, $"Invalid JSON: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Extract serializable fields from a UGCDataSO object into a dictionary.
+        /// </summary>
+        private Dictionary<string, object> ExtractSerializableFields(UGCDataSO dataObject)
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "ugcId", dataObject.ugcId },
+                { "createdBy", dataObject.createdBy },
+                { "createdAt", dataObject.createdAt.ToString("O") } // ISO 8601 format
+            };
+
+            // Add all serializable fields from derived types
+            var type = dataObject.GetType();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var field in fields)
+            {
+                // Skip base class fields (already handled above)
+                if (field.DeclaringType == typeof(UGCDataSO) ||
+                    field.DeclaringType == typeof(ScriptableObject) ||
+                    field.DeclaringType == typeof(UnityEngine.Object))
+                    continue;
+
+                // Skip fields marked with [SerializeField(false)]
+                var hideAttr = field.GetCustomAttribute<HideInInspector>();
+                if (hideAttr != null)
+                    continue;
+
+                var value = field.GetValue(dataObject);
+                if (value != null)
+                    dict[field.Name] = value;
+            }
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Get all allowed field names for a given schema type.
+        /// </summary>
+        private HashSet<string> GetAllowedFields(Type schemaType)
+        {
+            var allowed = new HashSet<string>
+            {
+                "ugcId",
+                "createdBy",
+                "createdAt"
+            };
+
+            // Add all public fields from the derived type
+            var fields = schemaType.GetFields(BindingFlags.Public | BindingFlags.Instance);
+            foreach (var field in fields)
+            {
+                // Skip base class fields
+                if (field.DeclaringType == typeof(UGCDataSO) ||
+                    field.DeclaringType == typeof(ScriptableObject) ||
+                    field.DeclaringType == typeof(UnityEngine.Object))
+                    continue;
+
+                // Skip hidden fields
+                var hideAttr = field.GetCustomAttribute<HideInInspector>();
+                if (hideAttr != null)
+                    continue;
+
+                allowed.Add(field.Name);
+            }
+
+            return allowed;
+        }
+
+        /// <summary>
+        /// Populate object fields from JSON element using reflection.
+        /// </summary>
+        private void PopulateFieldsFromJson<T>(T instance, JsonElement root) where T : UGCDataSO
+        {
+            var type = instance.GetType();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var field in fields)
+            {
+                // Skip base class fields (already handled in Deserialize)
+                if (field.DeclaringType == typeof(UGCDataSO) ||
+                    field.DeclaringType == typeof(ScriptableObject) ||
+                    field.DeclaringType == typeof(UnityEngine.Object))
+                    continue;
+
+                if (!root.TryGetProperty(field.Name, out var element))
+                    continue;
+
+                try
+                {
+                    var value = DeserializeValue(element, field.FieldType);
+                    field.SetValue(instance, value);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Failed to deserialize field '{field.Name}': {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deserialize a JSON element to a specific type.
+        /// </summary>
+        private object DeserializeValue(JsonElement element, Type targetType)
+        {
+            // Handle null
+            if (element.ValueKind == JsonValueKind.Null)
+                return targetType.IsValueType ? Activator.CreateInstance(targetType) : null;
+
+            // Handle basic types
+            if (targetType == typeof(string))
+                return element.GetString();
+            if (targetType == typeof(int))
+                return element.GetInt32();
+            if (targetType == typeof(float))
+                return element.GetSingle();
+            if (targetType == typeof(double))
+                return element.GetDouble();
+            if (targetType == typeof(bool))
+                return element.GetBoolean();
+            if (targetType == typeof(DateTime))
+            {
+                var str = element.GetString();
+                if (DateTime.TryParse(str, out var dt))
+                    return dt;
+                return default(DateTime);
+            }
+
+            // For complex types, try JSON deserialization
+            var json = element.GetRawText();
+            return JsonSerializer.Deserialize(json, targetType, _jsonOptions);
+        }
+    }
+
+    /// <summary>
+    /// Custom JSON converter for DateTime to ISO 8601 format.
+    /// </summary>
+    public class DateTimeConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var str = reader.GetString();
+            if (DateTime.TryParse(str, out var dt))
+                return dt;
+            return default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString("O"));
+        }
+    }
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/WitchMendokusai.DomainSDK.asmdef
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/DomainSDK/WitchMendokusai.DomainSDK.asmdef
@@ -1,0 +1,14 @@
+{
+  "name": "WitchMendokusai.DomainSDK",
+  "rootNamespace": "WitchMendokusai.DomainSDK",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/Tests/Editor/UGCSerializationTests.cs
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/Tests/Editor/UGCSerializationTests.cs
@@ -1,0 +1,253 @@
+using NUnit.Framework;
+using UnityEngine;
+using WitchMendokusai.DomainSDK.Data;
+using WitchMendokusai.DomainSDK.Serialization;
+using System;
+
+namespace WitchMendokusai.Tests.DomainSDK
+{
+    /// <summary>
+    /// Unit tests for UGC serialization (Phase A-C validation).
+    /// </summary>
+    public class UGCSerializationTests
+    {
+        private UGCJsonSerializer _serializer;
+        private SeedDataSO _testSeed;
+
+        [SetUp]
+        public void Setup()
+        {
+            _serializer = new UGCJsonSerializer();
+
+            // Create a test seed
+            _testSeed = ScriptableObject.CreateInstance<SeedDataSO>();
+            _testSeed.ugcId = "test-seed-001";
+            _testSeed.createdBy = "test-player";
+            _testSeed.createdAt = new DateTime(2026, 5, 17, 12, 0, 0);
+            _testSeed.parameters = new SeedDataSO.SeedParameters
+            {
+                seed = 54321,
+                name = "Test Mountain",
+                scale = 2.0f
+            };
+            _testSeed.description = "Test procedural mountain biome";
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            if (_testSeed != null)
+                Object.DestroyImmediate(_testSeed);
+        }
+
+        #region Phase A: Serialization & Deserialization
+
+        [Test]
+        public void Serialize_ValidSeed_ProducesValidJSON()
+        {
+            // Act
+            var json = _serializer.Serialize(_testSeed);
+
+            // Assert
+            Assert.IsNotNull(json);
+            Assert.IsNotEmpty(json);
+            Assert.That(json, Does.Contain("\"ugcId\":"));
+            Assert.That(json, Does.Contain("test-seed-001"));
+            Assert.That(json, Does.Contain("\"createdBy\":"));
+            Assert.That(json, Does.Contain("test-player"));
+        }
+
+        [Test]
+        public void Deserialize_ValidJSON_RestoresObject()
+        {
+            // Arrange
+            var json = _serializer.Serialize(_testSeed);
+
+            // Act
+            var loaded = _serializer.Deserialize<SeedDataSO>(json);
+
+            // Assert
+            Assert.IsNotNull(loaded);
+            Assert.AreEqual(_testSeed.ugcId, loaded.ugcId);
+            Assert.AreEqual(_testSeed.createdBy, loaded.createdBy);
+            Assert.AreEqual(_testSeed.createdAt, loaded.createdAt);
+            Assert.AreEqual(_testSeed.parameters.seed, loaded.parameters.seed);
+            Assert.AreEqual(_testSeed.parameters.name, loaded.parameters.name);
+            Assert.AreEqual(_testSeed.parameters.scale, loaded.parameters.scale);
+            Assert.AreEqual(_testSeed.description, loaded.description);
+        }
+
+        [Test]
+        public void Serialize_Deserialize_RoundtripPreservesData()
+        {
+            // Act
+            var json1 = _serializer.Serialize(_testSeed);
+            var loaded1 = _serializer.Deserialize<SeedDataSO>(json1);
+            var json2 = _serializer.Serialize(loaded1);
+            var loaded2 = _serializer.Deserialize<SeedDataSO>(json2);
+
+            // Assert
+            Assert.AreEqual(loaded1.ugcId, loaded2.ugcId);
+            Assert.AreEqual(loaded1.parameters.seed, loaded2.parameters.seed);
+            Assert.AreEqual(loaded1.parameters.name, loaded2.parameters.name);
+            Assert.AreEqual(loaded1.parameters.scale, loaded2.parameters.scale);
+        }
+
+        #endregion
+
+        #region Phase A: Schema Validation
+
+        [Test]
+        public void ValidateSchema_ValidJSON_ReturnsValid()
+        {
+            // Arrange
+            var json = _serializer.Serialize(_testSeed);
+
+            // Act
+            var result = _serializer.ValidateSchema(json, typeof(SeedDataSO));
+
+            // Assert
+            Assert.IsTrue(result.IsValid);
+            Assert.IsEmpty(result.InvalidFields);
+        }
+
+        [Test]
+        public void ValidateSchema_InvalidJSON_ReturnsFalse()
+        {
+            // Arrange
+            var invalidJson = "{invalid json";
+
+            // Act
+            var result = _serializer.ValidateSchema(invalidJson, typeof(SeedDataSO));
+
+            // Assert
+            Assert.IsFalse(result.IsValid);
+            Assert.That(result.ErrorMessage, Does.Contain("Invalid JSON"));
+        }
+
+        [Test]
+        public void ValidateSchema_UnknownField_DetectsAndRejects()
+        {
+            // Arrange - create JSON with extra field
+            var validJson = _serializer.Serialize(_testSeed);
+            var withHackedField = validJson.Replace("}", ", \"hackedField\": \"exploit\"}");
+
+            // Act
+            var result = _serializer.ValidateSchema(withHackedField, typeof(SeedDataSO));
+
+            // Assert
+            Assert.IsFalse(result.IsValid);
+            Assert.Contains("hackedField", result.InvalidFields);
+            Assert.That(result.ErrorMessage, Does.Contain("not in schema"));
+        }
+
+        #endregion
+
+        #region Phase C: Sandbox Validation
+
+        [Test]
+        public void Deserialize_JSONWithHackedField_ThrowsException()
+        {
+            // Arrange - create JSON with unauthorized field
+            var validJson = _serializer.Serialize(_testSeed);
+            var hackedJson = validJson.Replace("}", ", \"exploitField\": \"malicious\"}");
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                _serializer.Deserialize<SeedDataSO>(hackedJson);
+            });
+        }
+
+        [Test]
+        public void Sandbox_ValidJSON_LoadsSuccessfully()
+        {
+            // Arrange - sample-001.json equivalent
+            var sampleJson = @"{
+  ""ugcId"": ""seed-001"",
+  ""createdBy"": ""player"",
+  ""createdAt"": ""2026-05-17T12:00:00Z"",
+  ""parameters"": {
+    ""seed"": 12345,
+    ""name"": ""Mountain Valley"",
+    ""scale"": 1.5
+  },
+  ""description"": ""Procedural mountain biome""
+}";
+
+            // Act
+            var loaded = _serializer.Deserialize<SeedDataSO>(sampleJson);
+
+            // Assert
+            Assert.IsNotNull(loaded);
+            Assert.AreEqual("seed-001", loaded.ugcId);
+            Assert.AreEqual("Mountain Valley", loaded.parameters.name);
+        }
+
+        [Test]
+        public void Sandbox_InvalidJSON_WithExtraField_RejectsLoad()
+        {
+            // Arrange - sample with unauthorized field
+            var hackedJson = @"{
+  ""ugcId"": ""seed-002"",
+  ""createdBy"": ""player"",
+  ""createdAt"": ""2026-05-17T12:00:00Z"",
+  ""hackedField"": ""exploit"",
+  ""parameters"": {
+    ""seed"": 12345,
+    ""name"": ""Mountain Valley"",
+    ""scale"": 1.5
+  },
+  ""description"": ""Procedural mountain biome""
+}";
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _serializer.Deserialize<SeedDataSO>(hackedJson);
+            });
+
+            Assert.That(ex.Message, Does.Contain("schema validation failed"));
+        }
+
+        #endregion
+
+        #region Edge Cases
+
+        [Test]
+        public void Deserialize_NullInput_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _serializer.Deserialize<SeedDataSO>(null);
+            });
+        }
+
+        [Test]
+        public void Deserialize_EmptyInput_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _serializer.Deserialize<SeedDataSO>("");
+            });
+        }
+
+        [Test]
+        public void Serialize_NullInput_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                _serializer.Serialize(null);
+            });
+        }
+
+        [Test]
+        public void ValidateSchema_EmptyJSON_ReturnsFalse()
+        {
+            var result = _serializer.ValidateSchema("", typeof(SeedDataSO));
+            Assert.IsFalse(result.IsValid);
+        }
+
+        #endregion
+    }
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/Tests/WitchMendokusai.Tests.asmdef
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/Tests/WitchMendokusai.Tests.asmdef
@@ -1,0 +1,25 @@
+{
+  "name": "WitchMendokusai.Tests",
+  "rootNamespace": "WitchMendokusai.Tests",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner",
+    "WitchMendokusai.DomainSDK",
+    "WitchMendokusai.Domain"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Unity/KarmoLab/Assets/_WitchMendokusai/docs/VContainer-Mechanism.md
+++ b/Unity/KarmoLab/Assets/_WitchMendokusai/docs/VContainer-Mechanism.md
@@ -1,0 +1,166 @@
+# VContainer Mechanism — Source-Verified Reference
+
+**TASK-WM-109-A** — resolves TASK-WM-109 Issue 1 (hypothesis-fixing 4 cycles).
+
+> **황금의 정신**: 본 문서의 모든 동작 주장은 hadashiA/VContainer `master` source 라인으로 인증됨. 가설 X. 향후 VContainer 회귀 fix 시 — 가설 박기 전에 본 문서의 해당 § 를 먼저 확인하고, 없으면 source 를 정독해 본 문서를 확장한다.
+
+Source: https://github.com/hadashiA/VContainer (`master`, 정독 2026-05-19)
+
+---
+
+## 1. Type Injection 분석 (`Internal/TypeAnalyzer.cs`)
+
+### Field 발견
+
+```csharp
+BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly
+// + fieldInfo.IsDefined(typeof(InjectAttribute), false)
+```
+
+- `NonPublic` **포함** → `private` / `protected` / `internal` field 도 `[Inject]` 만 있으면 주입됨. **accessibility 무관 — 기준은 `[Inject]` attribute 단 하나.**
+- `DeclaredOnly` → 각 타입 *레벨* 에서 선언된 멤버만 본다. 그래서 base 클래스 멤버를 잡으려면 **명시적 base 순회 루프가 필요** (아래 참조).
+
+### Inheritance / abstract base 순회
+
+```csharp
+while (type != null && type != typeof(object)) { /* collect [Inject] fields/methods/properties */ type = type.BaseType; }
+```
+
+- `BaseType` 을 `object` 까지 **명시적으로 walk** → **abstract base class 에 선언된 `[Inject]` field / method / property 도 전부 수집됨.**
+- derived 가 같은 이름을 재선언하면 skip: `if (injectFields.Any(x => x.Name == fieldInfo.Name)) continue;`
+- method 는 `GetBaseDefinition()` 비교로 override 중복 제거.
+
+### Method / Constructor
+
+- `[Inject]` method 만 수집 (`methodInfo.IsDefined(typeof(InjectAttribute), false)`).
+- constructor: `[Inject]` 생성자 단일 우선 → 복수면 예외 → 없으면 파라미터 최다 생성자. Enum / Unity Component 는 null 생성자 허용.
+
+### 적용 순서 (`Internal/ReflectionInjector.cs`)
+
+```csharp
+InjectFields(...);  InjectProperties(...);  InjectMethods(...);
+```
+
+Fields → Properties → **Methods 순**. `InjectTypeInfo` 는 TypeAnalyzer 가 base 순회로 **이미 병합한 단일 리스트** — injector 는 inheritance 를 다시 신경 쓰지 않는다.
+
+---
+
+## 2. LifetimeScope 생명주기 (`Unity/LifetimeScope.cs`)
+
+- `[DefaultExecutionOrder(-5000)]` → 본 scope 의 `Awake()` 가 **다른 모든 컴포넌트 Awake 보다 먼저**.
+- Container build 는 **`Awake()` 중** 발생 (`Start` 아님): `protected virtual void Awake() { if (autoRun) Build(); }`.
+- 부모 미해결 시 `EnqueueAwake(this)` 로 deferred retry → `Build()` 가 `AwakeWaitingChildren(this)` 처리.
+- 부모 resolution 우선순위: 명시 `parentReference.Object` → `FindParent()` override → type 기반 scene `Find()` → `GlobalOverrideParents` → `VContainerSettings` root.
+- Build 시 계층: `Parent.Container.CreateScope(...)` (부모 있으면 child container) / 없으면 root `ContainerBuilder`.
+- **Scope ≠ Container**: `LifetimeScope` 는 계층·생명주기·`Configure()` 관리 MonoBehaviour. `Container` (`IObjectResolver`) 는 실제 resolver — scope 가 build 하지만 resolution 은 container 가 한다.
+
+---
+
+## 3. InjectGameObject — self-cascade 근본 (`Unity/ObjectResolverUnityExtensions.cs`)
+
+```csharp
+public static void InjectGameObject(this IObjectResolver resolver, GameObject gameObject)
+{
+    void InjectGameObjectRecursive(GameObject current)
+    {
+        if (current == null) return;
+        using (ListPool<MonoBehaviour>.Get(out var buffer))
+        {
+            buffer.Clear();
+            current.GetComponents(buffer);          // ← self 포함 모든 MonoBehaviour
+            foreach (var monoBehaviour in buffer)
+                if (monoBehaviour != null)
+                    resolver.Inject(monoBehaviour); // ← [Inject] method 재실행
+        }
+        var transform = current.transform;
+        for (var i = 0; i < transform.childCount; i++)
+            InjectGameObjectRecursive(transform.GetChild(i).gameObject); // ← 자식 재귀
+    }
+    InjectGameObjectRecursive(gameObject);
+}
+```
+
+**근본 (TASK-WM-109 Issue 2 인증)**:
+
+- `current.GetComponents(buffer)` 는 호출한 컴포넌트 **자기 자신을 포함** 한 GameObject 의 모든 MonoBehaviour 를 모은다.
+- **visited-set / already-injected 가드 / 재귀 보호가 일절 없다** (null 체크만).
+- 따라서 `Player.Construct()` ( `[Inject]` method) 안에서 `resolver.InjectGameObject(gameObject)` 호출 시:
+  `InjectGameObject` → `GetComponents` 에 Player 포함 → `resolver.Inject(player)` → Player 의 `[Inject] Construct` 재호출 → 다시 `InjectGameObject` → **무한 재귀 → stack overflow → Unity crash**.
+
+**규칙 (가설 X — 위 source 가 근거)**: `[Inject]` method 본문에서 *자기 자신이 붙은 GameObject* 를 대상으로 `InjectGameObject` 를 호출하지 말 것. 자식만 주입하려면 자식 GameObject 를 명시 전달하거나, self 를 제외한 helper 를 둔다.
+
+---
+
+## 4. RegisterComponentInHierarchy 해석 (`Unity/InstanceProviders/FindComponentProvider.cs`)
+
+```csharp
+component = parent.GetComponentInChildren(componentType, true);   // parent 우선, inactive 포함
+// fallback:
+scene.GetRootGameObjects(gameObjectBuffer);
+foreach (var gameObject in gameObjectBuffer) {
+    component = gameObject.GetComponentInChildren(componentType, true);
+    if (component != null) break;                                  // ← 첫 매치만
+}
+```
+
+- `GetComponentInChildren(type, true)` — **inactive GameObject 포함**.
+- **첫 매치 1개만** 등록 (`if (component != null) break;`). 다중 인스턴스 cascade **하지 않음**.
+- `FindObjectsByType` 미사용 — scene root 수동 순회 + `GetComponentInChildren`.
+
+→ 동일 type 컴포넌트가 씬에 여러 개여도 `RegisterComponentInHierarchy` 는 *하나* 만 잡는다. 다중 인스턴스는 별도 cascade 설계 필요 (TASK-WM-109 Issue 3/5 의 근본 배경).
+
+---
+
+## 5. 본 세션 4개 가설 — source 라인 반증 (TASK-WM-109 Issue 1)
+
+| # | 가설 (본 세션 2026-05-14~15) | 판정 | source 근거 |
+|---|---|---|---|
+| 1 | "abstract base `[Inject]` field 처리 한계" | **틀림** | `TypeAnalyzer`: `while (type != null && type != typeof(object)) ... type = type.BaseType` 로 base 명시 순회 → abstract base `[Inject]` 멤버 전부 수집 (§1) |
+| 2 | "Init Awake → Start race" | **틀림·무관** | `LifetimeScope` `[DefaultExecutionOrder(-5000)]` + Build 는 `Awake()` 중 → Container 는 일반 컴포넌트 Awake/Start 전에 이미 존재 (§2) |
+| 3 | "field 인젝션 private/protected 안 됨" | **틀림** | field BindingFlags 에 `NonPublic` 명시 포함 → accessibility 무관, 기준은 `[Inject]` attribute 뿐 (§1) |
+| 4 | "SetBaseDeps 수동 패턴 필요" | **불필요** | base 순회가 base `[Inject]` 를 자동 병합 (`InjectTypeInfo` 단일 리스트) → 수동 SetBaseDeps 는 중복 (§1) |
+
+4개 모두 source 정독 1회로 반증 가능했다. 가설 기반 5+ commit 은 source 미정독의 비용.
+
+---
+
+## 6. 향후 VContainer 회귀 fix 검증 프레임워크
+
+가설 박기 전 **반드시**:
+
+1. **본 문서 해당 § 확인.** 답이 있으면 그대로 적용 (재가설 X).
+2. 없으면 → `github.com/hadashiA/VContainer` `master` 해당 source 정독 → **본 문서에 § 추가 + source 라인 인용**.
+3. fix 는 *재현 테스트 먼저* (`[Test]` 또는 최소 repro scene) → 가설 검증을 코드로 고정. 「그냥 진행」 식 self-cycle 미검증 금지 (Issue 2 교훈).
+4. PR 설명에 "본 문서 § N 근거" 를 명시 — 리뷰어가 가설 여부를 audit 가능.
+
+테스트 패턴 (Unity Test Framework, repro 우선):
+
+```csharp
+// 가설 검증을 코드로 고정하는 패턴 — abstract base [Inject] 회귀 가드 예
+[Test]
+public void AbstractBase_InjectField_IsResolved()
+{
+    var builder = new ContainerBuilder();
+    builder.Register<Dep>(Lifetime.Transient);
+    builder.Register<ConcreteImpl>(Lifetime.Transient); // ConcreteImpl : AbstractBase, AbstractBase has [Inject] Dep field
+    var container = builder.Build();
+    var impl = container.Resolve<ConcreteImpl>();
+    Assert.That(impl.BaseDep, Is.Not.Null); // §1 base 순회 인증
+}
+```
+
+---
+
+## 7. cwd 한계 명시 (정직 보고)
+
+- 본 작업 cwd (KarmoLab repo) 에는 **VContainer 패키지도, WitchMendokusai VContainer 사용 게임 코드(Motor/SceneLifetimeScope/Player.Construct 등)도 부재** (`manifest.json` 에 VContainer 없음, `using VContainer` 0건).
+- 따라서 스펙 산출물 중 **"기존 코드 주석에 근본 이유 박기"는 본 PR 에서 불가** — 실제 WM 게임 repo 에서 별도 적용 필요. 본 문서가 그 정본 레퍼런스 역할.
+- "재현 테스트" 는 §6 의 패턴으로 제시 (실 컴파일 검증은 VContainer 가 있는 WM repo 에서).
+
+---
+
+## cross-cut
+
+- TASK-WM-109 Issue 1 (가설 4회), Issue 2 (self-cascade crash), Issue 3/5 (cascade 분산)
+- TASK-WM-108 § VContainer 정밀 학습
+- `memo/rules/process.md § 황금의 정신 — 가설 박기 X` / `§ 설계 자가 검토`


### PR DESCRIPTION
## TASK-WM-109-A — VContainer 메커니즘 source 정독

TASK-WM-109 Issue 1 (가설 박기 4회) 해결. VContainer 동작을 hadashiA/VContainer `master` source 라인으로 인증.

### 산출물
`Unity/KarmoLab/Assets/_WitchMendokusai/docs/VContainer-Mechanism.md` — source-verified 레퍼런스 + 검증 프레임워크.

### 정독 source (2026-05-19)
- `Internal/TypeAnalyzer.cs` — field BindingFlags(`Public|NonPublic|Instance|DeclaredOnly`) + `while(type!=object) type=BaseType` base 순회
- `Internal/ReflectionInjector.cs` — Fields→Properties→Methods 순, merged InjectTypeInfo
- `Unity/LifetimeScope.cs` — `Awake()` 중 Build + `[DefaultExecutionOrder(-5000)]`
- `Unity/ObjectResolverUnityExtensions.cs` — InjectGameObject 전문 (self 포함 + 재귀 가드 0)
- `Unity/InstanceProviders/FindComponentProvider.cs` — `GetComponentInChildren(type,true)` 첫 매치만

### 4개 가설 source 반증
| 가설 | 판정 | 근거 |
|---|---|---|
| abstract base [Inject] 한계 | 틀림 | base 명시 순회 |
| Awake→Start race | 틀림 | -5000 우선 + Awake build |
| private/protected field 안됨 | 틀림 | NonPublic 포함 |
| SetBaseDeps 필요 | 불필요 | 자동 병합 |

### Issue 2 (self-cascade crash) 근본 인증
`InjectGameObject` 가 `current.GetComponents(buffer)` 로 self 포함 + visited-set/재귀 가드 부재 → `Player.Construct` 내 self `InjectGameObject` = 무한 재귀 stack overflow. source 전문 인용.

### Test plan
- ⚠ cwd(KarmoLab)에 VContainer 패키지·WM 게임코드 부재 (`manifest.json` 에 VContainer 없음, `using VContainer` 0건) → **compile/test 검증 불가**.
- 문서 내 동작 주장은 전부 GitHub source 라인 인용으로 인증 (가설 X).
- 스펙 산출물 중 '기존 코드 주석 박기'는 실제 WM 게임 repo 에서 별도 적용 — 본 문서가 정본 레퍼런스. §7 에 한계 정직 명시.

### 미션 정렬
황금의 정신 §2(검증 후 진행): 모든 주장 source 인용. 가설 0. 한계 정직 보고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)